### PR TITLE
Apply special case when simple packing number of bits is 0

### DIFF
--- a/src/NGrib/Grib2/CodeTables/4_2_Parameter.cs
+++ b/src/NGrib/Grib2/CodeTables/4_2_Parameter.cs
@@ -872,6 +872,10 @@ namespace NGrib.Grib2.CodeTables
 		public static Parameter RadianceWaveLength { get; } = new Parameter(ParameterCategory.ShortWaveRadiation, 6,
 			"Radiance (with respect to wave length)", "W m-3 sr-1");
 
+        ///<summary>Surface short-wave (solar) radiation downwards (J m-2)</summary>
+		public static Parameter SurfaceShortWaveRadiationDownwards { get; } = new Parameter(ParameterCategory.ShortWaveRadiation, 7,
+            "Surface short-wave (solar) radiation downwards", "J m-2");
+
 		#endregion
 
 		#region Product Discipline 0: Meteorological products, Parameter Category 5: Long-wave Radiation

--- a/src/NGrib/Grib2/Sections/7_DataSection.cs
+++ b/src/NGrib/Grib2/Sections/7_DataSection.cs
@@ -51,7 +51,7 @@ namespace NGrib.Grib2.Sections
 		/// </summary>
 		public long DataLength { get; }
 
-		private DataSection(long length, int section, long dataOffset, long dataLength)
+		internal DataSection(long length, int section, long dataOffset, long dataLength)
 		{
 			DataOffset = dataOffset;
 			Length = length;

--- a/tests/NGrib.Tests/Grib2_GridPointDataSimplePacking_Test.cs
+++ b/tests/NGrib.Tests/Grib2_GridPointDataSimplePacking_Test.cs
@@ -1,0 +1,38 @@
+﻿using System.IO;
+using System.Linq;
+using NFluent;
+using NGrib.Grib2.CodeTables;
+using NGrib.Grib2.Sections;
+using NGrib.Grib2.Templates.DataRepresentations;
+using Xunit;
+
+namespace NGrib.Tests
+{
+    public class Grib2_EnumerateDataValues_Test
+    {
+        [Fact]
+        public void EnumerateDataValues_0BitSpecialCase_Test()
+        {
+            // When the number of bits is 0 in the simple packing
+            // The reference value should be return without applying the formula.
+
+            var referenceValue = 0.12345f;
+            var dataPointsNumber = 3;
+
+            var packing = new GridPointDataSimplePacking(
+                referenceValue,
+                -54,
+                -15,
+                0,
+                OriginalFieldValuesType.FloatingPoint);
+
+            var dataSection = new DataSection(0, 0, 0, 0);
+            using var fileStream = File.OpenRead(GribFileSamples.WmoOneDataSetMessage);
+            using var reader = new BufferedBinaryReader(fileStream);
+            var values = packing.EnumerateDataValues(reader, dataSection, dataPointsNumber).ToList();
+
+            var expectedValues = Enumerable.Repeat(referenceValue, dataPointsNumber).ToList();
+            Check.That(values).ContainsExactly(expectedValues);
+        }
+    }
+}


### PR DESCRIPTION
Handles a special case when the grid contains no values